### PR TITLE
build: make `ed25519.h` available

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft onionmaker/ed25519/src


### PR DESCRIPTION
Fixes digicert/onionmaker#4 by adding a `MANIFEST.in` file to make `ed25519.h` available to the `setup.py build` command.