### PR TITLE
Support _ in the verification token

### DIFF
--- a/onionmaker/__main__.py
+++ b/onionmaker/__main__.py
@@ -22,7 +22,7 @@ APPLICANT_SIGNING_NONCE_OCTET_COUNT = 16
 PUBLIC_KEY_FILENAME = 'hs_ed25519_public_key'
 PRIVATE_KEY_FILENAME = 'hs_ed25519_secret_key'
 
-RANDOM_VALUE_REGEX = re.compile(r'^[a-z0-9]{32}$', re.IGNORECASE)
+RANDOM_VALUE_REGEX = re.compile(r'^[a-z0-9_]{32}$', re.IGNORECASE)
 
 
 def _validate_random_value(value):


### PR DESCRIPTION
The random nonce is 32 alphanumeric characters, but recently digicert supplied us one with an underscore. This was being rejected, so we now make _ acceptable